### PR TITLE
Add Svelte v4 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vite": "^4.3.9"
   },
   "peerDependencies": {
-    "svelte": "^3.46.4"
+    "svelte": "^3.46.4 || ^4.0.0"
   },
   "description": "Svelte Hamburgers is a component based on the popular hamburgers.css",
   "author": "GHOST",


### PR DESCRIPTION
The peerDependencies field in package.json was using Svelte v3, but now that v4 is out we need to list it to avoid getting warnings on `npm install`.

Closes #107 